### PR TITLE
Bump flutter from 3.24.1 to 3.24.2

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.24.1",
+  "flutter": "3.24.2",
   "flavors": {}
 }

--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "5874a72aa4c779a02553007c47dacbefba2374dc"
+  revision: "4cf269e36de2573851eaef3c763994f8f9be494d"
   channel: "stable"
 
 project_type: app
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
+      base_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
     - platform: android
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
+      base_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
     - platform: ios
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
+      base_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
     - platform: linux
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
+      base_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
     - platform: macos
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
+      base_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
     - platform: web
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
+      base_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
     - platform: windows
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
+      base_revision: 4cf269e36de2573851eaef3c763994f8f9be494d
 
   # User provided section
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm/versions/3.24.1"
+  "dart.flutterSdkPath": ".fvm/versions/3.24.2"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version "8.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 
 include ":app"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -299,5 +299,5 @@ packages:
     source: hosted
     version: "5.5.5"
 sdks:
-  dart: ">=3.5.1 <4.0.0"
-  flutter: ">=3.24.1"
+  dart: ">=3.5.2 <4.0.0"
+  flutter: ">=3.24.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,8 @@ version: 1.0.0+1
 
 # https://docs.flutter.dev/release/archive
 environment:
-  sdk: ^3.5.1
-  flutter: '3.24.1'
+  sdk: ^3.5.2
+  flutter: '3.24.2'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- Flutterのバージョンが3.24.1から3.24.2に更新されました。
- **改善**
	- Android GradleプラグインとKotlinプラグインのバージョンがそれぞれ8.1.0と1.8.22に更新されました。
	- Gradleのバージョンが7.6.3から8.3に更新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
