### PR TITLE
Bump flutter from 3.27.1 to 3.27.2

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.27.1",
+  "flutter": "3.27.2",
   "flavors": {}
 }

--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "17025dd88227cd9532c33fa78f5250d548d87e9a"
+  revision: "68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3"
   channel: "stable"
 
 project_type: app
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      create_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
+      base_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
     - platform: android
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      create_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
+      base_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
     - platform: ios
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      create_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
+      base_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
     - platform: linux
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      create_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
+      base_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
     - platform: macos
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      create_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
+      base_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
     - platform: web
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      create_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
+      base_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
     - platform: windows
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      create_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
+      base_revision: 68415ad1d920f6fe5ec284f5c2febf7c4dd5b0b3
 
   # User provided section
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm/versions/3.27.1"
+  "dart.flutterSdkPath": ".fvm/versions/3.27.2"
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -299,5 +299,5 @@ packages:
     source: hosted
     version: "5.10.1"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.1"
+  dart: ">=3.6.1 <4.0.0"
+  flutter: ">=3.27.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,8 @@ version: 1.0.0+1
 
 # https://docs.flutter.dev/release/archive
 environment:
-  sdk: ^3.6.0
-  flutter: '3.27.1'
+  sdk: ^3.6.1
+  flutter: '3.27.2'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Flutter のバージョンを最新の安定版（3.27.2）に更新し、互換性とパフォーマンスの向上を実現しました。
	- プロジェクトにおける内部識別子が刷新され、各プラットフォーム間の整合性が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->