### PR TITLE
Bump flutter from 3.27.3 to 3.27.4

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.27.3",
+  "flutter": "3.27.4",
   "flavors": {}
 }

--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "c519ee916eaeb88923e67befb89c0f1dabfa83e6"
+  revision: "d8a9f9a52e5af486f80d932e838ee93861ffd863"
   channel: "stable"
 
 project_type: app
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
-      base_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
+      create_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
+      base_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
     - platform: android
-      create_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
-      base_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
+      create_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
+      base_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
     - platform: ios
-      create_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
-      base_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
+      create_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
+      base_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
     - platform: linux
-      create_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
-      base_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
+      create_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
+      base_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
     - platform: macos
-      create_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
-      base_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
+      create_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
+      base_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
     - platform: web
-      create_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
-      base_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
+      create_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
+      base_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
     - platform: windows
-      create_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
-      base_revision: c519ee916eaeb88923e67befb89c0f1dabfa83e6
+      create_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
+      base_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
 
   # User provided section
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm/versions/3.27.3"
+  "dart.flutterSdkPath": ".fvm/versions/3.27.4"
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -286,10 +286,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   win32:
     dependency: transitive
     description:
@@ -299,5 +299,5 @@ packages:
     source: hosted
     version: "5.10.1"
 sdks:
-  dart: ">=3.6.1 <4.0.0"
-  flutter: ">=3.27.3"
+  dart: ">=3.6.2 <4.0.0"
+  flutter: ">=3.27.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,8 @@ version: 1.0.0+1
 
 # https://docs.flutter.dev/release/archive
 environment:
-  sdk: ^3.6.1
-  flutter: '3.27.3'
+  sdk: ^3.6.2
+  flutter: '3.27.4'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Flutter SDK のバージョンを最新の安定版に更新しました。
	- 各プラットフォーム向けの内部識別情報を最新の状態に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->